### PR TITLE
Allow passing swc plugins

### DIFF
--- a/scripts/bundle.ts
+++ b/scripts/bundle.ts
@@ -51,7 +51,9 @@ module.exports.default = react;`,
 ]).then(() => {
   execSync("cp LICENSE README.md dist/");
 
-  execSync("tsc src/index.ts --declaration --emitDeclarationOnly --outDir dist --module es2020 --moduleResolution node");
+  execSync(
+    "tsc src/index.ts --declaration --emitDeclarationOnly --outDir dist --module es2020 --moduleResolution node",
+  );
 
   writeFileSync(
     "dist/package.json",

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ export type PluginProps = {
    *
    * @see {@link https://swc.rs/docs/configuration/compilation#jscexperimental SWC JSC experimental docs}
    */
-  experimentalJscConfig?: JscConfig['experimental'],
+  experimentalJscConfig?: JscConfig["experimental"];
 };
 
 const react = ({ experimentalJscConfig }: PluginProps = {}): PluginOption[] => [


### PR DESCRIPTION
Congrats on the Vite 4 release & stability of this plugin!

I tried to convert a React/Relay project of mine over to use this, but ran into a few issues. I'm using the [Relay Babel plugin](https://www.npmjs.com/package/babel-plugin-relay) which performs a couple of compile time substitutions. There's an _almost compatible_ SWC plugin (https://github.com/swc-project/plugins/pull/122), but `@vitejs/plugin-react-swc` doesn't currently support passing plugins down to SWC.

This PR `experimentalJscConfig` plugin prop.

There's an existing issue https://github.com/vitejs/vite-plugin-react-swc/issues/16 about supporting SWC configuration. My understanding is this should also allow using the plugin during the build phase and therefore has a wider scope, meanwhile this PR may unblock some from using this plugin who rely on plugins which already have an SWC counterpart & can take the hit of using a different plugin for build.

E.g., my config looks like

```ts
import path from "node:path";
import { defineConfig } from "vite";
import react from "@vitejs/plugin-react-swc";
import relayBabel from "vite-plugin-relay";

export default defineConfig(({ command }) => ({
  server: {
    port: 4000,
    host: "127.0.0.1"
  },
  plugins: command === 'serve'
    ? [react({
      experimentalJscConfig: {
        plugins: [[
          '@swc/plugin-relay',
          {
            language: "typescript",
            schema: path.resolve(__dirname, '..', 'graphql-server', 'schema.graphql'),
            rootDir: __dirname,
            src: "src",
            eagerEsModules: true,
            artifactDirectory: path.resolve(__dirname, 'src', '__generated__'),
          },
        ]]
      }
    })]
    : [react(), relayBabel],
}));
```