### PR TITLE
fix: compatibility with react-refresh runtime in @vitejs/plugin-react

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - fix: commonjs default export (fixes [#14](https://github.com/vitejs/vite-plugin-react-swc/issues/14))
 - fix: support Vite base option (fixes [#18](https://github.com/vitejs/vite-plugin-react-swc/issues/18))
-- fix: compatibility with react-refresh runtime in @vitejs/plugin-react (#20)
+- fix: compatibility with react-refresh runtime in @vitejs/plugin-react ([#20](https://github.com/vitejs/vite-plugin-react-swc/pull/20))
 
 ## 3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - fix: commonjs default export (fixes [#14](https://github.com/vitejs/vite-plugin-react-swc/issues/14))
 - fix: support Vite base option (fixes [#18](https://github.com/vitejs/vite-plugin-react-swc/issues/18))
+- fix: compatibility with react-refresh runtime in @vitejs/plugin-react (#20)
 
 ## 3.0.0
 

--- a/src/refresh-runtime.js
+++ b/src/refresh-runtime.js
@@ -630,3 +630,10 @@ function predicateOnExport(moduleExports, predicate) {
   }
   return true;
 }
+
+export default {
+ getRefreshReg,
+ injectIntoGlobalHook,
+ createSignatureFunctionForTransform,
+ validateRefreshBoundaryAndEnqueueUpdate,
+}

--- a/src/refresh-runtime.js
+++ b/src/refresh-runtime.js
@@ -631,6 +631,7 @@ function predicateOnExport(moduleExports, predicate) {
   return true;
 }
 
+// For backwards compatibility with @vitejs/plugin-react.
 export default {
  getRefreshReg,
  injectIntoGlobalHook,

--- a/src/refresh-runtime.js
+++ b/src/refresh-runtime.js
@@ -633,8 +633,8 @@ function predicateOnExport(moduleExports, predicate) {
 
 // For backwards compatibility with @vitejs/plugin-react.
 export default {
- getRefreshReg,
- injectIntoGlobalHook,
- createSignatureFunctionForTransform,
- validateRefreshBoundaryAndEnqueueUpdate,
-}
+  getRefreshReg,
+  injectIntoGlobalHook,
+  createSignatureFunctionForTransform,
+  validateRefreshBoundaryAndEnqueueUpdate,
+};


### PR DESCRIPTION
### Description 📖 

This pull request fixes compatibility with the [runtime served](https://github.com/vitejs/vite-plugin-react/blob/d71849ccd8ed58640e7a0327a6fa7672a4482e53/packages/plugin-react/src/fast-refresh.ts#L27) by `@vitejs/plugin-react`.

### Background 📜 

The preamble used in the [`@vitejs/plugin-react`](https://github.com/vitejs/vite-plugin-react/blob/d71849ccd8ed58640e7a0327a6fa7672a4482e53/packages/plugin-react/src/fast-refresh.ts#L31) plugin [imports](https://github.com/vitejs/vite-plugin-react/blob/d71849ccd8ed58640e7a0327a6fa7672a4482e53/packages/plugin-react/src/fast-refresh.ts#L31) the [default export](https://github.com/vitejs/vite-plugin-react/blob/d71849ccd8ed58640e7a0327a6fa7672a4482e53/packages/plugin-react/src/fast-refresh.ts#L27) from the runtime, calling `injectIntoGlobalHook` from it.

In contrast, the runtime [served by this plugin](https://github.com/facebook/react/blob/main/packages/react-refresh/src/ReactFreshRuntime.js) does not provide a default export.

This affects compatibility with external integrations, such as [Vite Ruby](https://github.com/ElMassimo/vite_ruby/blob/c7b9714e445ca55ef1a1331eb70889ee47cc7e7d/vite_ruby/lib/vite_ruby/manifest.rb#L54) and the [Laravel Vite](https://github.com/laravel/framework/blob/3480b7c34a58cad66ff02bc8695cec0ec818a7fe/src/Illuminate/Foundation/Vite.php#L606) integration, which were implemented to use the same preamble as the one used by `@vitejs/plugin-react`.

### The Fix 🔨 

Adding a default export to the runtime served by this plugin.

It doesn't affect backwards compatibility, so it can be shipped in a patch release.

### Notes ✏️ 

Although we could potentially modify the `@vitejs/plugin-react` plugin instead to use named exports, it would remain incompatible with previous versions of the backend integrations and other consumers of the runtime.

This change has significantly less friction, and would allow any users of `@vitejs/plugin-react` in backend integrations to seamlessly switch to this plugin.