### PR TITLE
fix: transform JSX living in `node_modules/`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,8 +42,6 @@ const react = (): PluginOption[] => [
       },
     ],
     async transform(code, id, transformOptions) {
-      if (id.includes("node_modules")) return;
-
       const parser: ParserConfig | undefined = id.endsWith(".tsx")
         ? { syntax: "typescript", tsx: true }
         : id.endsWith(".ts")


### PR DESCRIPTION
I understand the performance optimization of skipping `node_modules/` but AFAICT `if (!parser) return;` works equally well.

One use case for this is React Server Components where JSX files are living in `node_modules/`. (If you're curious: [discussion with the React team about this](https://github.com/reactjs/rfcs/pull/227#issuecomment-1320859947).)

(Thanks for `vite-plugin-react-swc`, I'm really liking it and already using it production.)