### PR TITLE
feat: add define in configuration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ type Options = {
    * @default "react"
    */
   jsxImportSource?: string;
+  define?: { [key: string]: string } | undefined;
 };
 
 const react = (options?: Options): PluginOption[] => [
@@ -81,6 +82,7 @@ const react = (options?: Options): PluginOption[] => [
                 runtime: "automatic",
                 importSource: options?.jsxImportSource,
               },
+              optimizer: { globals: { vars: options?.define } },
             },
           },
         });
@@ -135,6 +137,7 @@ import(/* @vite-ignore */ import.meta.url).then((currentExports) => {
       esbuild: {
         jsx: "automatic",
         jsxImportSource: options?.jsxImportSource,
+        define: options?.define,
         tsconfigRaw: { compilerOptions: { useDefineForClassFields: true } },
       },
     }),


### PR DESCRIPTION
## Description
This PR adds the `define` property in the plugin configurations, which has same semantics with `esbuild.define` property.

## Background
I'm currently migrating a custom swc react-refresh plugin into the `@vitejs/plugin-react-swc`.
The project, which I was migrating, was using a globally defined variable , `RUN_MODE`.  (which resolves to `"prod" | "stage" | "dev"` in the compile time)

And I have found out that enabling this plugin disables replacing some identifiers with some values in the compile time(, which was done via the esbuild.define property), so I have added a config for the defined variables.

## Implementation
I have added the `{ define?: { [key: string]: string } | undefined }` option in the plugin configurations.
This option is passed to the `jsc.transform.optimizer.globals.vars` in the serve mode, and it is passed to the `esbuild.define` in the build mode.
