### PR TITLE
chore: fix build on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsx scripts/bundle.ts",
     "test": "playwright test",
     "prettier": "pnpm prettier-ci --write",
-    "prettier-ci": "prettier --cache --ignore-path=.gitignore --check '**/*.{js,jsx,ts,tsx,html,css,json,md,yml}'",
+    "prettier-ci": "prettier --cache --ignore-path=.gitignore --check \"**/*.{js,jsx,ts,tsx,html,css,json,md,yml}\"",
     "ci": "tsc && pnpm prettier-ci && pnpm build && cd playground && tsc && cd .. && pnpm test",
     "release": "pnpm build && tsx scripts/release.ts"
   },

--- a/scripts/bundle.ts
+++ b/scripts/bundle.ts
@@ -51,8 +51,8 @@ module.exports.default = react;`,
     outfile: "dist/index.mjs",
   }),
 ]).then(() => {
-  copyFileSync('LICENSE', 'dist/LICENSE');
-  copyFileSync('README.md', 'dist/README.md');
+  copyFileSync("LICENSE", "dist/LICENSE");
+  copyFileSync("README.md", "dist/README.md");
 
   execSync(
     "tsc src/index.ts --declaration --emitDeclarationOnly --outDir dist --module es2020 --moduleResolution node",

--- a/scripts/bundle.ts
+++ b/scripts/bundle.ts
@@ -1,4 +1,4 @@
-import { rmSync, writeFileSync } from "node:fs";
+import { rmSync, writeFileSync, copyFileSync } from "node:fs";
 import { execSync } from "node:child_process";
 import { build, BuildOptions, context } from "esbuild";
 
@@ -51,7 +51,8 @@ module.exports.default = react;`,
     outfile: "dist/index.mjs",
   }),
 ]).then(() => {
-  execSync("cp LICENSE README.md dist/");
+  copyFileSync('LICENSE', 'dist/LICENSE');
+  copyFileSync('README.md', 'dist/README.md');
 
   execSync(
     "tsc src/index.ts --declaration --emitDeclarationOnly --outDir dist --module es2020 --moduleResolution node",


### PR DESCRIPTION
Running `pnpm build` on windows was failing because of `cp LICENSE README.md dist/`.
This PR rewrites that with `fs.copyFileSync`.

Also this PR fixes prettier command that didn't run on windows.
