### PR TITLE
chore: fix flaky test

### DIFF
--- a/playground/shadow-export/__tests__/shadow-export.spec.ts
+++ b/playground/shadow-export/__tests__/shadow-export.spec.ts
@@ -1,9 +1,11 @@
 import { expect, test } from "@playwright/test";
-import { setupDevServer } from "../../utils";
+import { setupDevServer, setupWaitForLogs } from "../../utils";
 
 test("Shadow export HMR", async ({ page }) => {
   const { testUrl, server, editFile } = await setupDevServer("shadow-export");
+  const waitForLogs = await setupWaitForLogs(page)
   await page.goto(testUrl);
+  await waitForLogs('registered')
 
   editFile("src/App.tsx", ["Shadow export", "Shadow export updates!"]);
   await expect(page.locator("body")).toHaveText("Shadow export updates!");

--- a/playground/shadow-export/__tests__/shadow-export.spec.ts
+++ b/playground/shadow-export/__tests__/shadow-export.spec.ts
@@ -5,7 +5,8 @@ test("Shadow export HMR", async ({ page }) => {
   const { testUrl, server, editFile } = await setupDevServer("shadow-export");
   const waitForLogs = await setupWaitForLogs(page);
   await page.goto(testUrl);
-  await waitForLogs("registered");
+  await waitForLogs("[vite] connected.");
+  await expect(page.locator("body")).toHaveText("Shadow export");
 
   editFile("src/App.tsx", ["Shadow export", "Shadow export updates!"]);
   await expect(page.locator("body")).toHaveText("Shadow export updates!");

--- a/playground/shadow-export/__tests__/shadow-export.spec.ts
+++ b/playground/shadow-export/__tests__/shadow-export.spec.ts
@@ -3,9 +3,9 @@ import { setupDevServer, setupWaitForLogs } from "../../utils";
 
 test("Shadow export HMR", async ({ page }) => {
   const { testUrl, server, editFile } = await setupDevServer("shadow-export");
-  const waitForLogs = await setupWaitForLogs(page)
+  const waitForLogs = await setupWaitForLogs(page);
   await page.goto(testUrl);
-  await waitForLogs('registered')
+  await waitForLogs("registered");
 
   editFile("src/App.tsx", ["Shadow export", "Shadow export updates!"]);
   await expect(page.locator("body")).toHaveText("Shadow export updates!");

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,7 +109,6 @@ import(/* @vite-ignore */ import.meta.url).then((currentExports) => {
     const invalidateMessage = RefreshRuntime.validateRefreshBoundaryAndEnqueueUpdate(currentExports, nextExports);
     if (invalidateMessage) import.meta.hot.invalidate(invalidateMessage);
   });
-  console.log('registered');
 });
 `;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,6 +109,7 @@ import(/* @vite-ignore */ import.meta.url).then((currentExports) => {
     const invalidateMessage = RefreshRuntime.validateRefreshBoundaryAndEnqueueUpdate(currentExports, nextExports);
     if (invalidateMessage) import.meta.hot.invalidate(invalidateMessage);
   });
+  console.log('registered');
 });
 `;
 


### PR DESCRIPTION
`playground/shadow-export/__tests__/shadow-export.spec.ts` seems to be flaky.

I guess the file is edited before `import.meta.hot.accept` is called.

This PR is a POC of a fix.
