### PR TITLE
perf: wrap dynamic import to skip analysis of dynamic imports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -107,7 +107,7 @@ ${result.code}
 
 window.$RefreshReg$ = prevRefreshReg;
 window.$RefreshSig$ = prevRefreshSig;
-import(/* @vite-ignore */ import.meta.url).then((currentExports) => {
+RefreshRuntime.__hmr_import(import.meta.url).then((currentExports) => {
   RefreshRuntime.registerExportsForReactRefresh("${id}", currentExports);
   import.meta.hot.accept((nextExports) => {
     if (!nextExports) return;

--- a/src/refresh-runtime.js
+++ b/src/refresh-runtime.js
@@ -612,5 +612,9 @@ function predicateOnExport(moduleExports, predicate) {
   return true;
 }
 
+// Hides vite-ignored dynamic import so that Vite can skip analysis if no other
+// dynamic import is present (https://github.com/vitejs/vite/pull/12732)
+export const __hmr_import = (module) => import(/* @vite-ignore */ module);
+
 // For backwards compatibility with @vitejs/plugin-react.
 export default { injectIntoGlobalHook };


### PR DESCRIPTION
Re: https://github.com/vitejs/vite/pull/12732

I will do the same change the Babel plugin once merged