### PR TITLE
fix: Add `enforce: "pre"` to mdx plugin so build script works

### DIFF
--- a/playground/mdx/vite.config.ts
+++ b/playground/mdx/vite.config.ts
@@ -3,5 +3,5 @@ import mdx from "@mdx-js/rollup";
 import react from "@vitejs/plugin-react-swc";
 
 export default defineConfig({
-  plugins: [mdx(), react()],
+  plugins: [{ enforce: "pre", ...mdx() }, react()],
 });


### PR DESCRIPTION
Adds solution referenced here: https://github.com/vitejs/vite-plugin-react/blob/main/playground/mdx/vite.config.ts#L8

Without it, the `build` script throws:

```
[vite:react-swc]
  × Expected ident
```