### PR TITLE
fix: better invalidation message when an export is added & fix HMR for export of nullish values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Disable Fast Refresh based on `config.server.hmr === false` instead of `process.env.TEST`
 - Warn when plugin is in WebContainers (see [#118](https://github.com/vitejs/vite-plugin-react-swc/issues/118))
+- Better invalidation message when an export is added & fix HMR for export of nullish values ([#143](https://github.com/vitejs/vite-plugin-react-swc/issues/143))
 
 ## 3.3.2
 

--- a/playground/hmr/__tests__/hmr.spec.ts
+++ b/playground/hmr/__tests__/hmr.spec.ts
@@ -46,7 +46,7 @@ test("HMR invalidate", async ({ page }) => {
     'React!";\nexport const useless = 3;',
   ]);
   await waitForLogs(
-    "[vite] invalidate /src/TitleWithExport.tsx: Could not Fast Refresh. Learn more at https://github.com/vitejs/vite-plugin-react-swc#consistent-components-exports",
+    "[vite] invalidate /src/TitleWithExport.tsx: Could not Fast Refresh (new export)",
     "[vite] hot updated: /src/App.tsx",
   );
 

--- a/src/refresh-runtime.js
+++ b/src/refresh-runtime.js
@@ -587,8 +587,11 @@ export function validateRefreshBoundaryAndEnqueueUpdate(
   prevExports,
   nextExports,
 ) {
-  if (!predicateOnExport(prevExports, (key) => !!nextExports[key])) {
+  if (!predicateOnExport(prevExports, (key) => key in nextExports)) {
     return "Could not Fast Refresh (export removed)";
+  }
+  if (!predicateOnExport(nextExports, (key) => key in prevExports)) {
+    return "Could not Fast Refresh (new export)";
   }
 
   let hasExports = false;
@@ -597,7 +600,6 @@ export function validateRefreshBoundaryAndEnqueueUpdate(
     (key, value) => {
       hasExports = true;
       if (isLikelyComponentType(value)) return true;
-      if (!prevExports[key]) return false;
       return prevExports[key] === nextExports[key];
     },
   );


### PR DESCRIPTION
This currently invalidate HMR if you export `0` or other nullish values