### PR TITLE
feat: add support for `.mts` (fixes #161)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add support for `.mts` (fixes [#161](https://github.com/vitejs/vite-plugin-react-swc/issues/161))
+
 ## 3.4.0
 
 - Add `devTarget` option (fixes [#141](https://github.com/vitejs/vite-plugin-react-swc/issues/141))

--- a/src/index.ts
+++ b/src/index.ts
@@ -205,7 +205,7 @@ const transformWithOptions = async (
   const decorators = options?.tsDecorators ?? false;
   const parser: ParserConfig | undefined = id.endsWith(".tsx")
     ? { syntax: "typescript", tsx: true, decorators }
-    : id.endsWith(".ts")
+    : id.endsWith(".ts") || id.endsWith(".mts")
     ? { syntax: "typescript", tsx: false, decorators }
     : id.endsWith(".jsx")
     ? { syntax: "ecmascript", jsx: true }


### PR DESCRIPTION
Using CJS in source code will not work in Vite (and will never be supported), so this is best to directly use `.ts`. But this align with the current default of Vite core: https://vitejs.dev/config/shared-options.html#resolve-extensions
This maybe reverted in a future major.
- Fixes #161
- Closes #162