### PR TITLE
chore: fix tsc build moduleResolution

### DIFF
--- a/scripts/bundle.ts
+++ b/scripts/bundle.ts
@@ -57,7 +57,7 @@ module.exports.default = react;`,
   copyFileSync("README.md", "dist/README.md");
 
   execSync(
-    "tsc src/index.ts --declaration --emitDeclarationOnly --outDir dist --module es2020 --moduleResolution node",
+    "tsc src/index.ts --declaration --emitDeclarationOnly --outDir dist --module es2020 --moduleResolution bundler",
     { stdio: "inherit" },
   );
 


### PR DESCRIPTION
Fix https://github.com/vitejs/vite-ecosystem-ci/actions/runs/6741485059/job/18326160111#step:8:770

Vite 5 re-exports `rollup/parseAst` which requires TypeScript to respect the `"exports"` field for types.