### PR TITLE
feat: enable custom transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ For production target, see https://vitejs.dev/config/build-options.html#build-ta
 react({ devTarget: "es2022" });
 ```
 
+## customTransform
+
+Additional options for SWC transform.
+
+```ts
+react({ customTransform: { legacyDecorator: true } });
+```
+
 ## Consistent components exports
 
 For React refresh to work correctly, your file should only export React components. The best explanation I've read is the one from the [Gatsby docs](https://www.gatsbyjs.com/docs/reference/local-development/fast-refresh/#how-it-works).

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {
   ReactConfig,
   JscTarget,
   transform,
+  TransformConfig,
 } from "@swc/core";
 import { PluginOption, UserConfig, BuildOptions } from "vite";
 import { createRequire } from "module";
@@ -50,6 +51,11 @@ type Options = {
    * @default "es2020"
    */
   devTarget?: JscTarget;
+  /**
+   * Additional options for SWC transform.
+   * @default undefined
+   */
+  customTransform?: TransformConfig;
 };
 
 const isWebContainer = globalThis.process?.versions?.webcontainer;
@@ -230,6 +236,7 @@ const transformWithOptions = async (
         transform: {
           useDefineForClassFields: true,
           react: reactConfig,
+          ...options.customTransform,
         },
       },
     });


### PR DESCRIPTION
I don't really see a good reason for not allowing users to pass down configuration to swc transform. Doing so enables using `legacyDecorators` (which currently blocks us from trying out vite-plugin-react-swc).