### PR TITLE
feat: add parserConfig option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-### Add filter option
+### Add parserConfig option
 
 This will unlock to use the plugin in some use cases where the original source code is not in TS. Using this option to keep using JSX inside `.js` files is highly discouraged and can be removed in any future version.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Add filter option
+
+This will unlock to use the plugin in some use cases where the original source code is not in TS. Using this option to keep using JSX inside `.js` files is highly discouraged and can be removed in any future version.
+
 ## 3.5.0
 
 ### Update peer dependency range to target Vite 5

--- a/README.md
+++ b/README.md
@@ -76,16 +76,20 @@ For production target, see https://vitejs.dev/config/build-options.html#build-ta
 react({ devTarget: "es2022" });
 ```
 
-### filter
+### parserConfig
 
-Override the default filtering (.ts, .tsx, .mts, .jsx, .mdx).
+Override the default include list (.ts, .tsx, .mts, .jsx, .mdx).
+
+This requires to redefine the config for any file you want to be included (ts, mdx, ...).
 
 If you want to trigger fast refresh on compiled JS, use `jsx: true`. Exclusion of node_modules should be handled by the function if needed. Using this option to use JSX inside `.js` files is highly discouraged and can be removed in any future version.
 
 ```ts
 react({
-  filter: (id) =>
-    id.endsWith(".res") ? { syntax: "ecmascript", jsx: true } : undefined,
+  parserConfig(id) {
+    if (id.endsWith(".res")) return { syntax: "ecmascript", jsx: true };
+    if (id.endsWith(".ts")) return { syntax: "typescript", tsx: false };
+  },
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Enable TypeScript decorators. Requires `experimentalDecorators` in tsconfig.
 react({ tsDecorators: true });
 ```
 
-## plugins
+### plugins
 
 Use SWC plugins. Enable SWC at build time.
 
@@ -64,7 +64,7 @@ Use SWC plugins. Enable SWC at build time.
 react({ plugins: [["@swc/plugin-styled-components", {}]] });
 ```
 
-## devTarget
+### devTarget
 
 Set the target for SWC in dev. This can avoid to down-transpile private class method for example.
 
@@ -74,6 +74,19 @@ For production target, see https://vitejs.dev/config/build-options.html#build-ta
 
 ```ts
 react({ devTarget: "es2022" });
+```
+
+### filter
+
+Override the default filtering (.ts, .tsx, .mts, .jsx, .mdx).
+
+If you want to trigger fast refresh on compiled JS, use `jsx: true`. Exclusion of node_modules should be handled by the function if needed. Using this option to use JSX inside `.js` files is highly discouraged and can be removed in any future version.
+
+```ts
+react({
+  filter: (id) =>
+    id.endsWith(".res") ? { syntax: "ecmascript", jsx: true } : undefined,
+});
 ```
 
 ## Consistent components exports

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,11 +51,12 @@ type Options = {
    */
   devTarget?: JscTarget;
   /**
-   * Override the default filtering (.ts, .tsx, .mts, .jsx, .mdx)
-   * If you want to trigger fast refresh on compiled JS, use `jsx: true`
-   * Exclusion of node_modules should be handled by the function if needed
+   * Override the default include list (.ts, .tsx, .mts, .jsx, .mdx).
+   * This requires to redefine the config for any file you want to be included.
+   * If you want to trigger fast refresh on compiled JS, use `jsx: true`.
+   * Exclusion of node_modules should be handled by the function if needed.
    */
-  filter?: (id: string) => ParserConfig | undefined;
+  parserConfig?: (id: string) => ParserConfig | undefined;
 };
 
 const isWebContainer = globalThis.process?.versions?.webcontainer;
@@ -69,7 +70,7 @@ const react = (_options?: Options): PluginOption[] => {
       ? _options?.plugins.map((el): typeof el => [resolve(el[0]), el[1]])
       : undefined,
     devTarget: _options?.devTarget ?? "es2020",
-    filter: _options?.filter,
+    parserConfig: _options?.parserConfig,
   };
 
   return [
@@ -211,8 +212,8 @@ const transformWithOptions = async (
   reactConfig: ReactConfig,
 ) => {
   const decorators = options?.tsDecorators ?? false;
-  const parser: ParserConfig | undefined = options.filter
-    ? options.filter(id)
+  const parser: ParserConfig | undefined = options.parserConfig
+    ? options.parserConfig(id)
     : id.endsWith(".tsx")
     ? { syntax: "typescript", tsx: true, decorators }
     : id.endsWith(".ts") || id.endsWith(".mts")

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,12 @@ type Options = {
    * @default "es2020"
    */
   devTarget?: JscTarget;
+  /**
+   * Override the default filtering (.ts, .tsx, .mts, .jsx, .mdx)
+   * If you want to trigger fast refresh on compiled JS, use `jsx: true`
+   * Exclusion of node_modules should be handled by the function if needed
+   */
+  filter?: (id: string) => ParserConfig | undefined;
 };
 
 const isWebContainer = globalThis.process?.versions?.webcontainer;
@@ -63,6 +69,7 @@ const react = (_options?: Options): PluginOption[] => {
       ? _options?.plugins.map((el): typeof el => [resolve(el[0]), el[1]])
       : undefined,
     devTarget: _options?.devTarget ?? "es2020",
+    filter: _options?.filter,
   };
 
   return [
@@ -204,7 +211,9 @@ const transformWithOptions = async (
   reactConfig: ReactConfig,
 ) => {
   const decorators = options?.tsDecorators ?? false;
-  const parser: ParserConfig | undefined = id.endsWith(".tsx")
+  const parser: ParserConfig | undefined = options.filter
+    ? options.filter(id)
+    : id.endsWith(".tsx")
     ? { syntax: "typescript", tsx: true, decorators }
     : id.endsWith(".ts") || id.endsWith(".mts")
     ? { syntax: "typescript", tsx: false, decorators }


### PR DESCRIPTION
Fixes #182

I didn't go with the classic `include/exclude` because this allow to return parser object and giving full control for the user at very low cost