### PR TITLE
Update refresh utils for Remix support

### DIFF
--- a/playground/hmr/__tests__/hmr.spec.ts
+++ b/playground/hmr/__tests__/hmr.spec.ts
@@ -35,7 +35,7 @@ test("HMR invalidate", async ({ page }) => {
   // Edit export
   editFile("src/TitleWithExport.tsx", ["React", "React!"]);
   await waitForLogs(
-    "[vite] invalidate /src/TitleWithExport.tsx: Could not Fast Refresh (framework export is incompatible). Learn more at https://github.com/vitejs/vite-plugin-react-swc#consistent-components-exports",
+    '[vite] invalidate /src/TitleWithExport.tsx: Could not Fast Refresh ("framework" export is incompatible). Learn more at https://github.com/vitejs/vite-plugin-react-swc#consistent-components-exports',
     "[vite] hot updated: /src/App.tsx",
   );
   await expect(page.locator("h1")).toHaveText("Vite * React!");

--- a/playground/hmr/__tests__/hmr.spec.ts
+++ b/playground/hmr/__tests__/hmr.spec.ts
@@ -35,7 +35,7 @@ test("HMR invalidate", async ({ page }) => {
   // Edit export
   editFile("src/TitleWithExport.tsx", ["React", "React!"]);
   await waitForLogs(
-    "[vite] invalidate /src/TitleWithExport.tsx: Could not Fast Refresh. Learn more at https://github.com/vitejs/vite-plugin-react-swc#consistent-components-exports",
+    "[vite] invalidate /src/TitleWithExport.tsx: Could not Fast Refresh (framework export is incompatible). Learn more at https://github.com/vitejs/vite-plugin-react-swc#consistent-components-exports",
     "[vite] hot updated: /src/App.tsx",
   );
   await expect(page.locator("h1")).toHaveText("Vite * React!");

--- a/src/index.ts
+++ b/src/index.ts
@@ -162,7 +162,7 @@ RefreshRuntime.__hmr_import(import.meta.url).then((currentExports) => {
   RefreshRuntime.registerExportsForReactRefresh("${id}", currentExports);
   import.meta.hot.accept((nextExports) => {
     if (!nextExports) return;
-    const invalidateMessage = RefreshRuntime.validateRefreshBoundaryAndEnqueueUpdate(currentExports, nextExports);
+    const invalidateMessage = RefreshRuntime.validateRefreshBoundaryAndEnqueueUpdate("${id}", currentExports, nextExports);
     if (invalidateMessage) import.meta.hot.invalidate(invalidateMessage);
   });
 });

--- a/src/refresh-runtime.js
+++ b/src/refresh-runtime.js
@@ -581,8 +581,12 @@ function debounce(fn, delay) {
   };
 }
 
-const enqueueUpdate = debounce(() => {
-  window.__beforePerformReactRefresh?.();
+const hooks = [];
+window.__registerBeforePerformReactRefresh = (cb) => {
+  hooks.push(cb);
+};
+const enqueueUpdate = debounce(async () => {
+  if (hooks.length) await Promise.all(hooks.map((cb) => cb()));
   performReactRefresh();
 }, 16);
 
@@ -624,7 +628,7 @@ export function validateRefreshBoundaryAndEnqueueUpdate(
   if (hasExports && allExportsAreComponentsOrUnchanged === true) {
     enqueueUpdate();
   } else {
-    return `Could not Fast Refresh (${allExportsAreComponentsOrUnchanged} export is incompatible). Learn more at https://github.com/vitejs/vite-plugin-react-swc#consistent-components-exports`;
+    return `Could not Fast Refresh ("${allExportsAreComponentsOrUnchanged}" export is incompatible). Learn more at https://github.com/vitejs/vite-plugin-react-swc#consistent-components-exports`;
   }
 }
 

--- a/src/refresh-runtime.js
+++ b/src/refresh-runtime.js
@@ -581,21 +581,39 @@ function debounce(fn, delay) {
   };
 }
 
-const enqueueUpdate = debounce(performReactRefresh, 16);
+const enqueueUpdate = debounce(() => {
+  window.__beforePerformReactRefresh?.();
+  performReactRefresh();
+}, 16);
 
 export function validateRefreshBoundaryAndEnqueueUpdate(
+  id,
   prevExports,
   nextExports,
 ) {
-  if (!predicateOnExport(prevExports, (key) => key in nextExports)) {
+  const ignoredExports = window.__getReactRefreshIgnoredExports?.({ id }) ?? [];
+  if (
+    predicateOnExport(
+      ignoredExports,
+      prevExports,
+      (key) => key in nextExports,
+    ) !== true
+  ) {
     return "Could not Fast Refresh (export removed)";
   }
-  if (!predicateOnExport(nextExports, (key) => key in prevExports)) {
+  if (
+    predicateOnExport(
+      ignoredExports,
+      nextExports,
+      (key) => key in prevExports,
+    ) !== true
+  ) {
     return "Could not Fast Refresh (new export)";
   }
 
   let hasExports = false;
   const allExportsAreComponentsOrUnchanged = predicateOnExport(
+    ignoredExports,
     nextExports,
     (key, value) => {
       hasExports = true;
@@ -603,19 +621,20 @@ export function validateRefreshBoundaryAndEnqueueUpdate(
       return prevExports[key] === nextExports[key];
     },
   );
-  if (hasExports && allExportsAreComponentsOrUnchanged) {
+  if (hasExports && allExportsAreComponentsOrUnchanged === true) {
     enqueueUpdate();
   } else {
-    return "Could not Fast Refresh. Learn more at https://github.com/vitejs/vite-plugin-react-swc#consistent-components-exports";
+    return `Could not Fast Refresh (${allExportsAreComponentsOrUnchanged} export is incompatible). Learn more at https://github.com/vitejs/vite-plugin-react-swc#consistent-components-exports`;
   }
 }
 
-function predicateOnExport(moduleExports, predicate) {
+function predicateOnExport(ignoredExports, moduleExports, predicate) {
   for (const key in moduleExports) {
     if (key === "__esModule") continue;
+    if (ignoredExports.includes(key)) continue;
     const desc = Object.getOwnPropertyDescriptor(moduleExports, key);
-    if (desc && desc.get) return false;
-    if (!predicate(key, moduleExports[key])) return false;
+    if (desc && desc.get) return key;
+    if (!predicate(key, moduleExports[key])) return key;
   }
   return true;
 }


### PR DESCRIPTION
`__beforePerformReactRefresh` & `__getReactRefreshIgnoredExports` will not be part of semver until Remiix on Vite is stable (and without Fast Refresh related stuff being vendored).

I'll do the same on the Babel plugin once I've got some positif feedback from @pcattori