### PR TITLE
Add swcImplementation option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Add swcImplementation option
+
+Pass a custom SWC implementation. This can be used to keep a stable version of SWC instead of using package manager overrides, at the cost of installing it twice.
+
 ## 3.6.0
 
 ### Add parserConfig option

--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ react({
 });
 ```
 
+### swcImplementation
+
+Advanced. Pass a custom SWC implementation. This can be used to keep a stable version of SWC instead of using package manager overrides, at the cost of installing it twice.
+
 ## Consistent components exports
 
 For React refresh to work correctly, your file should only export React components. The best explanation I've read is the one from the [Gatsby docs](https://www.gatsbyjs.com/docs/reference/local-development/fast-refresh/#how-it-works).


### PR DESCRIPTION
Addressing: https://github.com/vitejs/vite-plugin-react/issues/429

The other case it would be useful is when people have issues with breaking changes in the plugin API and want use another version of SWC. Ideally it should be done via package manager, but it very different from one case to another so I could have a generic message like: 

Use your package manager overrides to install v1.X.X or add `"@swc/core": "1.X.X"` to your package.json and use
```ts
import swc from "@swc/core";
import react from "@vitejs/plugin-react-swc";

export default defineConfig({
  plugins: [react({ swcImplementation: swc })],
});
```