### PR TITLE
fix: React in WebWorker window is undefined

### DIFF
--- a/playground/worker/__tests__/worker.spec.ts
+++ b/playground/worker/__tests__/worker.spec.ts
@@ -18,7 +18,7 @@ test("Worker HMR", async ({ page }) => {
   const { testUrl, server, editFile } = await setupDevServer("worker");
   const waitForLogs = await setupWaitForLogs(page);
   await page.goto(testUrl);
-  await waitForLogs("Worker lives!", "Worker imported!");
+  await waitForLogs("Worker lives!", "Worker imported!", "Worker with react lives!");
 
   editFile("src/worker-via-url.ts", ["Worker lives!", "Worker updates!"]);
   await waitForLogs("Worker updates!");

--- a/playground/worker/src/App.tsx
+++ b/playground/worker/src/App.tsx
@@ -1,7 +1,9 @@
 import { useState } from "react";
 import MyWorker from "./worker-via-import.ts?worker&inline";
+import MyWorkerWithReact from "./worker-via-import-with-react?worker";
 
 new MyWorker();
+new MyWorkerWithReact();
 
 export const App = () => {
   const [count, setCount] = useState(0);

--- a/playground/worker/src/worker-via-import-with-react.tsx
+++ b/playground/worker/src/worker-via-import-with-react.tsx
@@ -1,0 +1,12 @@
+function MyComponent() {
+  console.log("MyComponent: ", <div>Hi!</div>);
+}
+
+function printAlive(): void {
+  console.log("Worker with react lives!");
+  MyComponent();
+}
+
+printAlive();
+
+export {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -167,9 +167,6 @@ if (import.meta.hot && !inWebWorker) {
   prevRefreshSig = window.$RefreshSig$;
   window.$RefreshReg$ = RefreshRuntime.getRefreshReg("${id}");
   window.$RefreshSig$ = RefreshRuntime.createSignatureFunctionForTransform;
-} else if (inWebWorker) {
-  // Provide noop for swc.
-  globalThis.$RefreshReg$ = () => {};
 }
 
 ${result.code}

--- a/src/refresh-runtime.js
+++ b/src/refresh-runtime.js
@@ -547,7 +547,7 @@ function isLikelyComponentType(type) {
  * Plugin utils
  */
 
-if (window.$RefreshReg$) {
+if (globalThis.$RefreshReg$) {
   throw new Error(
     "React refresh runtime was loaded twice. Maybe you forgot the base path?",
   );
@@ -582,7 +582,7 @@ function debounce(fn, delay) {
 }
 
 const hooks = [];
-window.__registerBeforePerformReactRefresh = (cb) => {
+globalThis.__registerBeforePerformReactRefresh = (cb) => {
   hooks.push(cb);
 };
 const enqueueUpdate = debounce(async () => {
@@ -595,7 +595,7 @@ export function validateRefreshBoundaryAndEnqueueUpdate(
   prevExports,
   nextExports,
 ) {
-  const ignoredExports = window.__getReactRefreshIgnoredExports?.({ id }) ?? [];
+  const ignoredExports = globalThis.__getReactRefreshIgnoredExports?.({ id }) ?? [];
   if (
     predicateOnExport(
       ignoredExports,


### PR DESCRIPTION
Previously the HMR code would use window as the global scope which is undefined in webworkers.

This change uses some code lifted from @vitejs/plugin-react to check if the context is in a webworker before doing trying to use `window`.

HMR is not currently possible in vite (https://github.com/vitejs/vite-plugin-react/issues/152) so nothing happens when the worker file is edited.