### PR TITLE
fix: add react and react-dom to resolve.dedupe at config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -94,6 +94,9 @@ const react = (_options?: Options): PluginOption[] => {
           include: [`${options.jsxImportSource}/jsx-dev-runtime`],
           esbuildOptions: { jsx: "automatic" },
         },
+        resolve: {
+          dedupe: ['react', 'react-dom'],
+        },
       }),
       configResolved(config) {
         if (config.server.hmr === false) hmrDisabled = true;


### PR DESCRIPTION
Adds "react" and "react-dom" to `resolve.dedupe` in the `config` hook. @vitejs/plugin-react does the same at https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/src/index.ts#L289-L291.

For some context, the missing dedupe of these React packages caused issues in my own React meta-framework ([@lazarv/react-server](https://github.com/lazarv/react-server)) when adding support for @vitejs/plugin-react-swc. Using Vite Environment API it was not able to resolve "react/jsx-dev-runtime". I usually work on the framework in a pnpm workspace and the framework also provides it's own strict experimental React version.