### PR TITLE
feat: Allow configuring the SWC env option

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,22 @@ react({
 });
 ```
 
+### env
+
+Configure the SWC env options.
+
+By default, build.target is used. However, the env option can provide for more fine-tuned browserlist support.
+
+See https://swc.rs/docs/configuration/compilation#env
+
+```ts
+react({
+  env: {
+    targets: ["last 4 chrome versions", "last 4 safari version", "ios>=15"],
+  },
+});
+```
+
 ## Consistent components exports
 
 For React refresh to work correctly, your file should only export React components. The best explanation I've read is the one from the [Gatsby docs](https://www.gatsbyjs.com/docs/reference/local-development/fast-refresh/#how-it-works).

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {
   ReactConfig,
   JscTarget,
   transform,
+  EnvConfig,
 } from "@swc/core";
 import { PluginOption, UserConfig, BuildOptions } from "vite";
 import { createRequire } from "module";
@@ -58,6 +59,13 @@ type Options = {
    * Exclusion of node_modules should be handled by the function if needed.
    */
   parserConfig?: (id: string) => ParserConfig | undefined;
+  /**
+   * Configure the SWC env options. By default, build.target is used.
+   * However, the env option can provide for more fine-tuned browserlist support.
+   * See https://swc.rs/docs/configuration/compilation#env
+   * @default undefined
+   */
+  env?: EnvConfig;
 };
 
 const isWebContainer = globalThis.process?.versions?.webcontainer;
@@ -72,6 +80,7 @@ const react = (_options?: Options): PluginOption[] => {
       : undefined,
     devTarget: _options?.devTarget ?? "es2020",
     parserConfig: _options?.parserConfig,
+    env: _options?.env,
   };
 
   return [
@@ -243,8 +252,9 @@ const transformWithOptions = async (
       swcrc: false,
       configFile: false,
       sourceMaps: true,
+      ...(options.env ? { env: options.env } : {}),
       jsc: {
-        target,
+        ...(options.env ? {} : { target }),
         parser,
         experimental: { plugins: options.plugins },
         transform: {


### PR DESCRIPTION
**Edit**: Vite comes with ESBuild transpiling which can be configured via `build.target`.

Polyfiling (of the like of babel-env) can also be enabled via [a custom plugin](https://github.com/vitejs/vite-plugin-react-swc/pull/236#issuecomment-2425050600)

Thus limiting the value of configuring the `env` parameter of SWC via vite-plugin-react-swc.

--

As opposed to its `@vitejs/plugin-react` counterpart, the react-swc plugin is limiting when it comes to configuring SWC. This can be problematic for a number of contexts and production apps.

This PR is proposing to make this plugin a little more agnostic (while preserving its good defaults) so that it can be a better flexible and non-opinionated proxy for using SWC with Vite.

Using `@vitejs/plugin-legacy` is not a viable alternative in many cases, as it defeats the intent and purpose of using the react-swc plugin (performance). The legacy plugin re-introduces babel and slows down build by a factor of 2x. It can be necessary for projects targeting true legacy environments, but it is unnecessary in most cases.

