### PR TITLE
feat: add useAtYourOwnRisk_mutateSwcOptions option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+### Add useAtYourOwnRisk_mutateSwcOptions option
+
+The future of Vite is with OXC, and from the beginning this was a design choice to not exposed too many specialties from SWC so that Vite React users can move to another transformer later.
+Also debugging why some specific version of decorators with some other unstable/legacy feature doesn't work is not fun, so we won't provide support for it, hence the name `useAtYourOwnRisk`.
+
+```ts
+react({
+  useAtYourOwnRisk_mutateSwcOptions(options) {
+    options.jsc.parser.decorators = true;
+    options.jsAc.transform.decoratorVersion = "2022-03";
+  },
+});
+```
+
 ## 3.7.2
 
 ### Add Vite 6 to peerDependencies range [#207](https://github.com/vitejs/vite-plugin-react-swc/pull/207)

--- a/README.md
+++ b/README.md
@@ -93,6 +93,20 @@ react({
 });
 ```
 
+### useAtYourOwnRiskEditConfig
+
+The future of Vite is with OXC, and from the beginning this was a design choice to not exposed too many specialties from SWC so that Vite React users can move to another transformer later.
+Also debugging why some specific version of decorators with some other unstable/legacy feature doesn't work is not fun, so we won't provide support for it, hence the name `useAtYourOwnRisk`.
+
+```ts
+react({
+  useAtYourOwnRiskEditConfig(options) {
+    options.jsc.parser.decorators = true;
+    options.jsc.transform.decoratorVersion = "2022-03";
+  },
+});
+```
+
 ## Consistent components exports
 
 For React refresh to work correctly, your file should only export React components. The best explanation I've read is the one from the [Gatsby docs](https://www.gatsbyjs.com/docs/reference/local-development/fast-refresh/#how-it-works).

--- a/README.md
+++ b/README.md
@@ -93,14 +93,14 @@ react({
 });
 ```
 
-### useAtYourOwnRiskEditConfig
+### useAtYourOwnRisk_mutateSwcOptions
 
 The future of Vite is with OXC, and from the beginning this was a design choice to not exposed too many specialties from SWC so that Vite React users can move to another transformer later.
 Also debugging why some specific version of decorators with some other unstable/legacy feature doesn't work is not fun, so we won't provide support for it, hence the name `useAtYourOwnRisk`.
 
 ```ts
 react({
-  useAtYourOwnRiskEditConfig(options) {
+  useAtYourOwnRisk_mutateSwcOptions(options) {
     options.jsc.parser.decorators = true;
     options.jsc.transform.decoratorVersion = "2022-03";
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {
   ReactConfig,
   JscTarget,
   transform,
+  type Options as SWCOptions,
 } from "@swc/core";
 import { PluginOption, UserConfig, BuildOptions } from "vite";
 import { createRequire } from "module";
@@ -58,6 +59,14 @@ type Options = {
    * Exclusion of node_modules should be handled by the function if needed.
    */
   parserConfig?: (id: string) => ParserConfig | undefined;
+  /**
+   * The future of Vite is with OXC, and from the beginning this was a design choice
+   * to not exposed too many specialties from SWC so that Vite React users can move to
+   * another transformer later.
+   * Also debugging why some specific version of decorators with some other unstable/legacy
+   * feature doesn't work is not fun, so we won't provide support for it, hence the name `useAtYourOwnRisk`
+   */
+  useAtYourOwnRiskEditConfig?: (options: SWCOptions) => void;
 };
 
 const isWebContainer = globalThis.process?.versions?.webcontainer;
@@ -72,6 +81,7 @@ const react = (_options?: Options): PluginOption[] => {
       : undefined,
     devTarget: _options?.devTarget ?? "es2020",
     parserConfig: _options?.parserConfig,
+    useAtYourOwnRiskEditConfig: _options?.useAtYourOwnRiskEditConfig,
   };
 
   return [
@@ -238,7 +248,7 @@ const transformWithOptions = async (
 
   let result: Output;
   try {
-    result = await transform(code, {
+    const swcOptions: SWCOptions = {
       filename: id,
       swcrc: false,
       configFile: false,
@@ -252,7 +262,11 @@ const transformWithOptions = async (
           react: reactConfig,
         },
       },
-    });
+    };
+    if (options.useAtYourOwnRiskEditConfig) {
+      options.useAtYourOwnRiskEditConfig(swcOptions);
+    }
+    result = await transform(code, swcOptions);
   } catch (e: any) {
     const message: string = e.message;
     const fileStartIndex = message.indexOf("╭─[");

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ type Options = {
    * Also debugging why some specific version of decorators with some other unstable/legacy
    * feature doesn't work is not fun, so we won't provide support for it, hence the name `useAtYourOwnRisk`
    */
-  useAtYourOwnRiskEditConfig?: (options: SWCOptions) => void;
+  useAtYourOwnRisk_mutateSwcOptions?: (options: SWCOptions) => void;
 };
 
 const isWebContainer = globalThis.process?.versions?.webcontainer;
@@ -81,7 +81,8 @@ const react = (_options?: Options): PluginOption[] => {
       : undefined,
     devTarget: _options?.devTarget ?? "es2020",
     parserConfig: _options?.parserConfig,
-    useAtYourOwnRiskEditConfig: _options?.useAtYourOwnRiskEditConfig,
+    useAtYourOwnRisk_mutateSwcOptions:
+      _options?.useAtYourOwnRisk_mutateSwcOptions,
   };
 
   return [
@@ -263,8 +264,8 @@ const transformWithOptions = async (
         },
       },
     };
-    if (options.useAtYourOwnRiskEditConfig) {
-      options.useAtYourOwnRiskEditConfig(swcOptions);
+    if (options.useAtYourOwnRisk_mutateSwcOptions) {
+      options.useAtYourOwnRisk_mutateSwcOptions(swcOptions);
     }
     result = await transform(code, swcOptions);
   } catch (e: any) {


### PR DESCRIPTION
For a long time I asked people to do a patch to get access to feature I don't want to maintain (hello not yet stable decorators)

I think this option will create less issues/PRs while still having the benefit that users know they are in a non standard setup.